### PR TITLE
Refactoriza la sección de estadísticas con utilidades Bootstrap

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,22 +54,26 @@
     </section>
 
     <!-- Stats Section -->
-    <section class="stats">
-        <div class="stat-item">
-            <div class="stat-number">15+</div>
-            <div class="stat-label">Años de experiencia</div>
-        </div>
-        <div class="stat-item">
-            <div class="stat-number">500+</div>
-            <div class="stat-label">Docentes capacitados anualmente</div>
-        </div>
-        <div class="stat-item">
-            <div class="stat-number">50+</div>
-            <div class="stat-label">Cursos y talleres</div>
-        </div>
-        <div class="stat-item">
-            <div class="stat-number">7</div>
-            <div class="stat-label">Áreas de especialización</div>
+    <section class="bg-white py-4">
+        <div class="container">
+            <div class="row text-center">
+                <div class="col-6 col-md-3 mb-4">
+                    <div class="fs-1 fw-bold text-primary">15+</div>
+                    <div class="small text-muted">Años de experiencia</div>
+                </div>
+                <div class="col-6 col-md-3 mb-4">
+                    <div class="fs-1 fw-bold text-primary">500+</div>
+                    <div class="small text-muted">Docentes capacitados anualmente</div>
+                </div>
+                <div class="col-6 col-md-3 mb-4">
+                    <div class="fs-1 fw-bold text-primary">50+</div>
+                    <div class="small text-muted">Cursos y talleres</div>
+                </div>
+                <div class="col-6 col-md-3 mb-4">
+                    <div class="fs-1 fw-bold text-primary">7</div>
+                    <div class="small text-muted">Áreas de especialización</div>
+                </div>
+            </div>
         </div>
     </section>
 

--- a/style/main.css
+++ b/style/main.css
@@ -111,31 +111,6 @@ body {
     border-color: #3b82f6;
 }
 
-/* Stats Section */
-.stats {
-    background: white;
-    padding: 40px 20px;
-    display: flex;
-    justify-content: center;
-    gap: 80px;
-}
-
-.stat-item {
-    text-align: center;
-}
-
-.stat-number {
-    font-size: 36px;
-    font-weight: bold;
-    color: #1e3a8a;
-}
-
-.stat-label {
-    font-size: 12px;
-    color: #6b7280;
-    margin-top: 5px;
-}
-
 /* About Section */
 .about-section {
     background: #f9fafb;
@@ -554,16 +529,6 @@ body {
 
     .hero p {
         font-size: 15px;
-    }
-
-    .stats {
-        flex-direction: column;
-        gap: 28px;
-        padding: 36px 16px;
-    }
-
-    .stat-number {
-        font-size: 30px;
     }
 
     .about-section,


### PR DESCRIPTION
## Summary
- Replace the stats section with Bootstrap grid and typography utilities for consistent layout and style.
- Remove custom `.stats` CSS rules that overlapped with Bootstrap.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b7b453fc8322a6278610f6c53a1f