### PR TITLE
Refactor footer layout using Bootstrap grid utilities

### DIFF
--- a/index.html
+++ b/index.html
@@ -280,45 +280,47 @@
 
     <!-- Footer -->
     <footer class="footer">
-        <div class="footer-container">
-            <div class="footer-column">
-                <h4>FES Aragón</h4>
-                <ul>
-                    <li><a href="#">Acerca de la Facultad</a></li>
-                    <li><a href="#">Historia</a></li>
-                    <li><a href="#">Misión y Visión</a></li>
-                    <li><a href="#">Directorio</a></li>
-                </ul>
-            </div>
-            <div class="footer-column">
-                <h4>Enlaces Rápidos</h4>
-                <ul>
-                    <li><a href="#">Inicio</a></li>
-                    <li><a href="#">Departamento</a></li>
-                    <li><a href="#">Cursos</a></li>
-                    <li><a href="#">Contacto</a></li>
-                </ul>
-            </div>
-            <div class="footer-column">
-                <h4>Contacto</h4>
-                <ul>
-                    <li><a href="#">55 5623 1000</a></li>
-                    <li><a href="#">planeacion.aragon@unam.mx</a></li>
-                    <li><a href="#">Av. Rancho Seco S/N, Nezahualcóyotl</a></li>
-                </ul>
-            </div>
-            <div class="footer-column">
-                <h4>Síguenos</h4>
-                <ul>
-                    <li><a href="#">Facebook</a></li>
-                    <li><a href="#">Twitter</a></li>
-                    <li><a href="#">YouTube</a></li>
-                    <li><a href="#">Instagram</a></li>
-                </ul>
+        <div class="container">
+            <div class="row py-5">
+                <div class="col-6 col-md-3 text-center text-md-start">
+                    <h5 class="mb-3">FES Aragón</h5>
+                    <ul class="list-unstyled">
+                        <li><a href="#">Acerca de la Facultad</a></li>
+                        <li><a href="#">Historia</a></li>
+                        <li><a href="#">Misión y Visión</a></li>
+                        <li><a href="#">Directorio</a></li>
+                    </ul>
+                </div>
+                <div class="col-6 col-md-3 text-center text-md-start">
+                    <h5 class="mb-3">Enlaces Rápidos</h5>
+                    <ul class="list-unstyled">
+                        <li><a href="#">Inicio</a></li>
+                        <li><a href="#">Departamento</a></li>
+                        <li><a href="#">Cursos</a></li>
+                        <li><a href="#">Contacto</a></li>
+                    </ul>
+                </div>
+                <div class="col-6 col-md-3 text-center text-md-start">
+                    <h5 class="mb-3">Contacto</h5>
+                    <ul class="list-unstyled">
+                        <li><a href="#">55 5623 1000</a></li>
+                        <li><a href="#">planeacion.aragon@unam.mx</a></li>
+                        <li><a href="#">Av. Rancho Seco S/N, Nezahualcóyotl</a></li>
+                    </ul>
+                </div>
+                <div class="col-6 col-md-3 text-center text-md-start">
+                    <h5 class="mb-3">Síguenos</h5>
+                    <ul class="list-unstyled">
+                        <li><a href="#">Facebook</a></li>
+                        <li><a href="#">Twitter</a></li>
+                        <li><a href="#">YouTube</a></li>
+                        <li><a href="#">Instagram</a></li>
+                    </ul>
+                </div>
             </div>
         </div>
-        <div class="footer-bottom">
-            <p>&copy; 2024 Facultad de Estudios Superiores Aragón - UNAM. Todos los derechos reservados.</p>
+        <div class="bg-dark text-white text-center py-3">
+            <p class="mb-0">&copy; 2024 Facultad de Estudios Superiores Aragón - UNAM. Todos los derechos reservados.</p>
         </div>
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>

--- a/style/main.css
+++ b/style/main.css
@@ -316,48 +316,29 @@ body {
 .footer {
     background: #1e3a8a;
     color: white;
-    padding: 40px 20px 20px;
 }
 
-.footer-container {
-    max-width: 1200px;
-    margin: 0 auto;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 40px;
-    margin-bottom: 30px;
-}
-
-.footer-column h4 {
+.footer h5 {
     font-size: 16px;
-    margin-bottom: 15px;
 }
 
-.footer-column ul {
-    list-style: none;
+.footer ul {
+    padding: 0;
 }
 
-.footer-column ul li {
+.footer ul li {
     margin-bottom: 10px;
 }
 
-.footer-column ul li a {
+.footer a {
     color: #cbd5e1;
     text-decoration: none;
     font-size: 14px;
     transition: color 0.3s;
 }
 
-.footer-column ul li a:hover {
+.footer a:hover {
     color: white;
-}
-
-.footer-bottom {
-    text-align: center;
-    padding-top: 20px;
-    border-top: 1px solid #334155;
-    color: #94a3b8;
-    font-size: 12px;
 }
 
 /* Mobile nav toggle */
@@ -477,15 +458,6 @@ body {
     }
 
     /* Footer ajuste padding lateral */
-    .footer {
-        padding-left: 16px;
-        padding-right: 16px;
-    }
-
-    .footer-container {
-        gap: 28px;
-    }
-
     /* Asegurar safe-area en dispositivos con notch */
     body {
         padding-left: max(0px, env(safe-area-inset-left));


### PR DESCRIPTION
## Summary
- Rebuild footer using Bootstrap's grid system and utility classes
- Drop custom flex/grid styles in favor of Bootstrap utilities
- Keep dark copyright bar using Bootstrap background/text helpers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c3946c3c8322ab410b69da39ee98